### PR TITLE
Exclude nan values from mean in gating method 2

### DIFF
--- a/resurfemg/helper_functions.py
+++ b/resurfemg/helper_functions.py
@@ -984,7 +984,7 @@ def gating(
     The filling method for the gate is encoded as follows:
     0: Filled with zeros
     1: Interpolation samples before and after
-    2: Filled with average of prior segment
+    2: Filled with average of prior segment. If no prior segment, fill with zeros
     3: Fill with running average of RMS (default)
 
     :param src_signal: Signal to process

--- a/resurfemg/helper_functions.py
+++ b/resurfemg/helper_functions.py
@@ -1033,9 +1033,14 @@ def gating(
     elif method == 2:
         # Method 2: Fill with window length mean over prior section
         for i, peak in enumerate(gate_peaks):
-            pre_ave_emg = np.nanmean(
-                src_signal[int(peak-1.5*gate_width): int(peak-gate_width/2-1)]
-                )
+            if int(peak-gate_width/2-2) < 0:
+                pre_ave_emg = 0
+            else:
+                k_start = max([0, int(peak-1.5*gate_width)])
+                k_end = int(peak-gate_width/2-1)
+                pre_ave_emg = np.nanmean(
+                    src_signal[k_start:k_end]
+                    )
 
             k_start = max([0, int(peak-gate_width/2)])
             k_end = min([int(peak+gate_width/2), src_signal_gated.shape[0]])

--- a/resurfemg/helper_functions.py
+++ b/resurfemg/helper_functions.py
@@ -1033,8 +1033,9 @@ def gating(
     elif method == 2:
         # Method 2: Fill with window length mean over prior section
         for i, peak in enumerate(gate_peaks):
-            pre_ave_emg = np.mean(
-                src_signal[int(peak-1.5*gate_width): int(peak-gate_width/2-1)])
+            pre_ave_emg = np.nanmean(
+                src_signal[int(peak-1.5*gate_width): int(peak-gate_width/2-1)]
+                )
 
             k_start = max([0, int(peak-gate_width/2)])
             k_end = min([int(peak+gate_width/2), src_signal_gated.shape[0]])

--- a/tests/test.py
+++ b/tests/test.py
@@ -329,6 +329,13 @@ class TestGating(unittest.TestCase):
             (len(self.sample_emg_filtered[0])),
             len(ecg_gated_2) ,
         )
+
+    def test_gating_method_2_no_prior_segment(self):
+        ecg_gated_2 = gating(self.sample_emg_filtered[0, :], [100], gate_width=205, method=2)
+
+        self.assertFalse(
+            np.isnan(np.sum(ecg_gated_2))
+        )
     
     def test_gating_method_3(self):
         ecg_peaks, _  = scipy.signal.find_peaks(self.sample_emg_filtered[0, :10*2048-1])


### PR DESCRIPTION
Fix ReSurfEMG/ReSurfEMG#143 ReSurfEMG/ReSurfEMG-dashboard#17
np.nanmean excludes nan values from the averaging window. 

If the windows exists of nan values only, it will still return a nan (both in method 2 and 3). I left this in as you probably want it to raise an error if you have your entire probing windows of nans: @fs=2048Hz, this would mean ~200 consecutive samples are nans, which probably mean your signal seriously corrupted.
