### PR TITLE
Fix file discovery

### DIFF
--- a/resurfemg/data_connector/file_discovery.py
+++ b/resurfemg/data_connector/file_discovery.py
@@ -51,6 +51,8 @@ def find_files(
         extension_regex = '**'
     elif not isinstance(extension_regex, str):
         raise ValueError('extension_regex should be a str.')
+    if extension_regex.startswith('.'):
+        extension_regex = extension_regex[1:]
 
     if isinstance(folder_levels, list):
         depth = len(folder_levels)

--- a/resurfemg/pipelines/ipy_widgets.py
+++ b/resurfemg/pipelines/ipy_widgets.py
@@ -108,22 +108,29 @@ def file_select(
             options = list(set(filter_files[dict_key].values))
             options.sort()
 
-            if any(btn_changed[:btn_idx]) or prev_values[btn_idx] is None:
-                if value_options_bool[btn_idx] is True:
-                    if default_value_select[btn_idx] in options:
-                        value = options[
-                            options.index(default_value_select[btn_idx])]
-                    elif len(options) > 0:
+            if len(options) > 0:
+                if any(btn_changed[:btn_idx]) or prev_values[btn_idx] is None:
+                    if value_options_bool[btn_idx] is True:
+                        if default_value_select[btn_idx] in options:
+                            value = options[
+                                options.index(default_value_select[btn_idx])]
+                        else:
+                            value = options[0]
+                    elif idx_options_bool[btn_idx] is True:
+                        if default_idx_select[btn_idx] < len(options):
+                            value = options[default_idx_select[btn_idx]]
+                        else:
+                            value = options[0]
+                    elif _btn.value in options:
+                        value = options[options.index(_btn.value)]
+                    else:
                         value = options[0]
-                elif idx_options_bool[btn_idx] is True:
-                    if default_idx_select[btn_idx] < len(options):
-                        value = options[default_idx_select[btn_idx]]
-                    elif len(options) > 0:
-                        value = options[0]
-            elif _btn.value in options:
-                value = options[options.index(_btn.value)]
-            elif len(options) > 0:
-                value = options[0]
+                elif _btn.value in options:
+                    value = options[options.index(_btn.value)]
+                else:
+                    value = options[0]
+            else:
+                value = None
 
             _btn.options = options
             if len(options) > 0:


### PR DESCRIPTION
- Default options were disabled in the ipy_widgets.file_select. This is fixed now.
- The file_discovery regex for the file_extension now accepts both `.ext` and `ext` as valid extensions. Was only `ext`