### PR TITLE
Minor bug fixes and improvements

### DIFF
--- a/resurfemg/data_connector/peakset_class.py
+++ b/resurfemg/data_connector/peakset_class.py
@@ -178,8 +178,7 @@ class PeaksSet:
         :returns: None
         :rtype: None
         """
-        valid_idxs = np.argwhere(self.peak_df['valid'])
-
+        valid_idxs = self.peak_df['valid'].to_numpy()
         self.peak_df = self.peak_df.loc[valid_idxs].reset_index(drop=True)
         self.quality_outcomes_df = \
             self.quality_outcomes_df.loc[valid_idxs].reset_index(drop=True)

--- a/resurfemg/data_connector/peakset_class.py
+++ b/resurfemg/data_connector/peakset_class.py
@@ -127,14 +127,16 @@ class PeaksSet:
             df_old = self.quality_values_df
             pre_existing_keys = list(
                 set(tests_df_new.keys()) & set(df_old.keys()))
-            pre_existing_keys.pop(pre_existing_keys.index('peak_idx'))
             df_old = df_old.drop(columns=pre_existing_keys)
-            tests_df_new = df_old.merge(
+            tests_df_merge = df_old.merge(
                 tests_df_new,
-                left_on='peak_idx',
-                right_on='peak_idx',
-                suffixes=(False, False))
-            self.quality_values_df = tests_df_new
+                left_index=True,
+                right_index=True)
+            if not self.quality_values_df['peak_idx'].equals(
+                    tests_df_merge['peak_idx']):
+                raise ValueError(
+                    "Mismatched 'peak_idx' between old and new dataframes.")
+            self.quality_values_df = tests_df_merge
         else:
             self.quality_values_df = tests_df_new
 
@@ -153,14 +155,16 @@ class PeaksSet:
             df_old = self.quality_outcomes_df
             pre_existing_keys = list(
                 set(tests_df_new.keys()) & set(df_old.keys()))
-            pre_existing_keys.pop(pre_existing_keys.index('peak_idx'))
             df_old = df_old.drop(columns=pre_existing_keys)
-            tests_df_new = df_old.merge(
+            tests_df_merge = df_old.merge(
                 tests_df_new,
-                left_on='peak_idx',
-                right_on='peak_idx',
-                suffixes=(False, False))
-            self.quality_outcomes_df = tests_df_new
+                left_index=True,
+                right_index=True)
+            if not self.quality_outcomes_df['peak_idx'].equals(
+                    tests_df_merge['peak_idx']):
+                raise ValueError(
+                    "Mismatched 'peak_idx' between old and new dataframes.")
+            self.quality_outcomes_df = tests_df_merge
         else:
             self.quality_outcomes_df = tests_df_new
 

--- a/resurfemg/pipelines/ipy_widgets.py
+++ b/resurfemg/pipelines/ipy_widgets.py
@@ -105,7 +105,7 @@ def file_select(
 
                 filter_files = files[np.all(np.array(bool_list), 0)]
 
-            options = list(set(filter_files[dict_key].values))
+            options = list(np.unique(filter_files[dict_key].values))
             options.sort()
 
             if len(options) > 0:


### PR DESCRIPTION
- Improve dataclass documentation
- Fix peak_set class evaluate_validity and update_test_outcomes to not break for duplicate peak_idx in peak_set. This can happen when linking peaksets where one peak is linked to two or more peaks in the other channel.
